### PR TITLE
[FEAT] 기록 삭제하기 API 구현 #27

### DIFF
--- a/src/controller/recordController.ts
+++ b/src/controller/recordController.ts
@@ -43,7 +43,7 @@ const getAllPet = async (req: Request, res: Response) => {
   }
 };
 
-//* 기록 삭제
+//* 기록 삭제하기
 const deleteRecord = async (req: Request, res: Response) => {
   const { recordId } = req.params;
 

--- a/src/controller/recordController.ts
+++ b/src/controller/recordController.ts
@@ -3,6 +3,7 @@ import { rm, sc } from '../constants';
 import { fail, success } from '../constants/response';
 import recordService from '../service/recordService';
 
+//* 수행하지 않은 미션 조회
 const getMission = async (req: Request, res: Response) => {
   try {
     //const userId: number = req.body.userId;
@@ -23,6 +24,7 @@ const getMission = async (req: Request, res: Response) => {
   }
 };
 
+//* 모든 펫 조회
 const getAllPet = async (req: Request, res: Response) => {
   try {
     const familyId = req.params.familyId;
@@ -41,8 +43,17 @@ const getAllPet = async (req: Request, res: Response) => {
   }
 };
 
+//* 기록 삭제
+const deleteRecord = async (req: Request, res: Response) => {
+  const { recordId } = req.params;
+
+  await recordService.deleteRecord(+recordId);
+  return res.status(sc.OK).send(success(sc.OK, rm.DELETE_RECORD_SUCCESS));
+};
+
 const recordController = {
   getMission,
   getAllPet,
+  deleteRecord,
 };
 export default recordController;

--- a/src/router/recordRouter.ts
+++ b/src/router/recordRouter.ts
@@ -9,4 +9,7 @@ router.get('/mission/:familyId', recordController.getMission);
 //? GET record/pet/{familyId}
 router.get('/pet/:familyId', recordController.getAllPet);
 
+//? DELETE record/{recordId}
+router.delete('/:recordId', recordController.deleteRecord);
+
 export default router;

--- a/src/service/recordService.ts
+++ b/src/service/recordService.ts
@@ -69,9 +69,18 @@ const getAllPet = async (familyId: number): Promise<PetDto[]> => {
   return familyService.getFamilyPets(familyId);
 };
 
+const deleteRecord = async (recordId: number): Promise<void> => {
+  await prisma.record.delete({
+    where: {
+      id: recordId,
+    },
+  });
+};
+
 const recordService = {
   getMission,
   getAllPet,
+  deleteRecord,
 };
 
 export default recordService;


### PR DESCRIPTION
## 🌱관련 이슈
Related to: 27 

## 📌 설명
기록 삭제하기 

## ✅ 완료 목록
- recordRouter 구현
- recordController 구현
- recordService 구현
- API 테스트 완료
- 
## ❓ 궁금한 점 & 리뷰 포인트
- 생성을 할 때는 record 테이블과  record_pet 테이블을 각각 생성해주었는데 삭제할 때는 record 테이블을 삭제하니 해당 record_id를 가진 record_pet 내용들도 삭제된다 ?_?
