### PR TITLE
로그인 api 응답에 기존 유저 여부 포함

### DIFF
--- a/src/controller/userController.ts
+++ b/src/controller/userController.ts
@@ -9,11 +9,14 @@ const signInKakao = async (req: Request, res: Response) => {
   const kakaoToken: string | undefined = headers?.split(' ')[1];
   // const kakaoToken = 'lrtqU2I-F20rF6-ChgSXkbY4ZjFi6-qijDKfmaLpCiolkQAAAYV330xt';
 
-  const jwtToken = await userService.signInKakao(kakaoToken);
+  const { jwtToken, isExistedUser } = await userService.signInKakao(kakaoToken);
 
-  return res
-    .status(200)
-    .send(success(sc.OK, rm.SIGNIN_SUCCESS, { jwtToken: jwtToken }));
+  return res.status(200).send(
+    success(sc.OK, rm.SIGNIN_SUCCESS, {
+      jwtToken: jwtToken,
+      isExistedUser: isExistedUser,
+    })
+  );
 };
 
 const signInApple = async (req: Request, res: Response, next: NextFunction) => {

--- a/src/controller/userController.ts
+++ b/src/controller/userController.ts
@@ -29,11 +29,17 @@ const signInApple = async (req: Request, res: Response, next: NextFunction) => {
     }
 
     const { identityTokenString } = req.body;
-    const jwtToken = await userService.verifyIdentityToken(identityTokenString);
 
-    return res
-      .status(200)
-      .send(success(sc.OK, rm.SIGNIN_SUCCESS, { jwtToken: jwtToken }));
+    const { jwtToken, isExistedUser } = await userService.verifyIdentityToken(
+      identityTokenString
+    );
+
+    return res.status(200).send(
+      success(sc.OK, rm.SIGNIN_SUCCESS, {
+        jwtToken: jwtToken,
+        isExistedUser: isExistedUser,
+      })
+    );
   } catch (error) {
     next(error);
     return res

--- a/src/interface/user/UserLoginResponseDto.ts
+++ b/src/interface/user/UserLoginResponseDto.ts
@@ -1,0 +1,4 @@
+export interface UserLoginResponseDto {
+  jwtToken: string;
+  isExistedUser: boolean;
+}

--- a/src/service/userService.ts
+++ b/src/service/userService.ts
@@ -55,7 +55,7 @@ const signInKakao = async (kakaoToken: string | undefined) => {
   //유저 없으면 회원가입
   if (!user) {
     const jwtToken = await signUp(kakaoId, 'kakao');
-    return jwtToken;
+    return { jwtToken: jwtToken, isExistedUser: true };
   }
   //유저 있으면 jwt 토큰 생성
   const userId = user.id;
@@ -73,7 +73,7 @@ const signInKakao = async (kakaoToken: string | undefined) => {
     },
   });
 
-  return jwtToken;
+  return { jwtToken: jwtToken, isExistedUser: false };
 };
 
 const getApplePublicKey = async () => {

--- a/src/service/userService.ts
+++ b/src/service/userService.ts
@@ -58,7 +58,7 @@ const signInKakao = async (
   //유저 없으면 회원가입
   if (!user) {
     const jwtToken = await signUp(kakaoId, 'kakao');
-    return { jwtToken: jwtToken, isExistedUser: true };
+    return { jwtToken: jwtToken, isExistedUser: false };
   }
   //유저 있으면 jwt 토큰 생성
   const userId = user.id;
@@ -76,7 +76,7 @@ const signInKakao = async (
     },
   });
 
-  return { jwtToken: jwtToken, isExistedUser: false };
+  return { jwtToken: jwtToken, isExistedUser: true };
 };
 
 const getApplePublicKey = async () => {


### PR DESCRIPTION
## 🌱관련 이슈
Related to: #102 

## 📌 설명
클라이언트의 요청사항으로 인한 API 수정
로그인 후 응답에 기존 유저인지 여부를 포함

## ✅ 완료 목록
카카오 로그인 api 수정
애플 로그인 api 수정

## ❓ 궁금한 점 & 리뷰 포인트
