### PR TITLE
댓글 삭제를 위해 상세보기에 댓글 id 정보 포함해서 리턴

### DIFF
--- a/src/interface/comment/CommentDto.ts
+++ b/src/interface/comment/CommentDto.ts
@@ -1,4 +1,5 @@
 export interface CommentDto {
+  commentId: number;
   isEmoji: boolean;
   writerId: number;
   nickName: string;

--- a/src/service/commentService.ts
+++ b/src/service/commentService.ts
@@ -28,6 +28,7 @@ const getAllComment = async (recordId: number): Promise<CommentDto[]> => {
     const commentDate = dayjs(comment.created_at).format('M월 D일');
 
     const data: CommentDto = {
+      commentId: comment.id,
       isEmoji: isEmoji,
       writerId: writer.id,
       nickName: writer.nick_name,

--- a/src/service/recordService.ts
+++ b/src/service/recordService.ts
@@ -409,6 +409,7 @@ const getAllRecordAos = async (
       const commentDate = dayjs(comment.created_at).format('M월 D일');
 
       const commentDto: CommentDto = {
+        commentId: comment.id,
         isEmoji: isEmoji,
         writerId: writer.id,
         nickName: writer.nick_name,


### PR DESCRIPTION
## 🌱관련 이슈
Related to: 

## 📌 설명
게시글 삭제를 위한 댓글 id 정보 포함

## ✅ 완료 목록
comment 인터페이스 수정
commentService 수정
recordService 기록 전체보기 메서드 수정

## ❓ 궁금한 점 & 리뷰 포인트
