### PR TITLE
[ADD] family 생성 후 familyId 리턴하는 코드 추가

### DIFF
--- a/src/controller/familyController.ts
+++ b/src/controller/familyController.ts
@@ -212,14 +212,18 @@ const createFamily = async (
       })
     );
 
-    await familyService.createFamily(
+    const familyId: number = await familyService.createFamily(
       userId,
       locations,
       petNames,
       isPetPhotosBoolean
     );
 
-    return res.status(sc.OK).send(success(sc.OK, rm.CREATE_FAMILY_SUCCESS));
+    return res
+      .status(sc.CREATED)
+      .send(
+        success(sc.CREATED, rm.CREATE_FAMILY_SUCCESS, { familyId: familyId })
+      );
   } catch (error) {
     next(error);
 

--- a/src/controller/recordController.ts
+++ b/src/controller/recordController.ts
@@ -202,7 +202,12 @@ const getRecordNew = async (
     if (!recordId)
       return res.status(sc.NOT_FOUND).send(fail(sc.NOT_FOUND, rm.NOT_FOUND));
 
-    const data = await recordService.getRecordNew(+familyId, +recordId, +petId);
+    const data = await recordService.getRecordNew(
+      req.body.userId,
+      +familyId,
+      +recordId,
+      +petId
+    );
     return res.status(sc.OK).send(success(sc.OK, rm.GET_RECORD_SUCCESS, data));
   } catch (error) {
     next(error);

--- a/src/controller/recordController.ts
+++ b/src/controller/recordController.ts
@@ -128,7 +128,11 @@ const getRecord = async (req: Request, res: Response, next: NextFunction) => {
     if (!recordId)
       return res.status(sc.NOT_FOUND).send(fail(sc.NOT_FOUND, rm.NOT_FOUND));
 
-    const data = await recordService.getRecord(+familyId, +recordId);
+    const data = await recordService.getRecord(
+      req.body.userId,
+      +familyId,
+      +recordId
+    );
     return res.status(sc.OK).send(success(sc.OK, rm.GET_RECORD_SUCCESS, data));
   } catch (error) {
     next(error);

--- a/src/interface/record/RecordResponseDto.ts
+++ b/src/interface/record/RecordResponseDto.ts
@@ -4,6 +4,7 @@ import { RecordDto } from './RecordDto';
 export interface RecordResponseDto {
   leftId: number | null;
   rightId: number | null;
+  userId: number;
   record: RecordDto;
   comments: CommentDto[];
 }

--- a/src/service/familyService.ts
+++ b/src/service/familyService.ts
@@ -223,7 +223,7 @@ const createFamily = async (
   petPhotos: string[],
   petNames: string[],
   isPetPhotosBoolean: boolean[]
-): Promise<void> => {
+): Promise<number> => {
   if (petPhotos.length !== petNames.length)
     throw new Error('Forget pet photos');
 
@@ -243,7 +243,9 @@ const createFamily = async (
     },
   });
 
-  createPets(petNames, petPhotos, isPetPhotosBoolean, family.id);
+  await createPets(petNames, petPhotos, isPetPhotosBoolean, family.id);
+
+  return family.id;
 };
 
 const familyService = {

--- a/src/service/recordService.ts
+++ b/src/service/recordService.ts
@@ -180,6 +180,7 @@ const createRecord = async (
 
 //* 기록 상세조회
 const getRecord = async (
+  userId: number,
   familyId: number,
   recordId: number
 ): Promise<RecordResponseDto> => {
@@ -234,6 +235,7 @@ const getRecord = async (
   const recordResponseDto: RecordResponseDto = {
     leftId: leftId,
     rightId: rightId,
+    userId: userId,
     record: recordDto,
     comments: recentComments,
   };

--- a/src/service/recordService.ts
+++ b/src/service/recordService.ts
@@ -444,6 +444,7 @@ const getAllRecordAos = async (
 
 //* 기록 상세조회 ( NEW !!!!!)
 const getRecordNew = async (
+  userId: number,
   familyId: number,
   recordId: number,
   petId: number
@@ -532,6 +533,7 @@ const getRecordNew = async (
   const recordResponseDto: RecordResponseDto = {
     leftId: leftId,
     rightId: rightId,
+    userId: userId,
     record: recordDto,
     comments: recentComments,
   };


### PR DESCRIPTION
## 🌱관련 이슈
Related to: 

## 📌 설명
온보딩에서 가족 생성하고 나면 가족 코드 복사를 하게되는데 그 때 가족 아이디를 서버에게 요청해야됨
플로우가 바로 이어지는 것을 생각해서 가족 생성 후 return에 familyId를 넣음

## ✅ 완료 목록

## ❓ 궁금한 점 & 리뷰 포인트
