### PR TITLE
[ADD] 기록 상세조회에 userId 리턴 빼기

### DIFF
--- a/src/interface/record/RecordResponseDto.ts
+++ b/src/interface/record/RecordResponseDto.ts
@@ -4,7 +4,6 @@ import { RecordDto } from './RecordDto';
 export interface RecordResponseDto {
   leftId: number | null;
   rightId: number | null;
-  userId: number;
   record: RecordDto;
   comments: CommentDto[];
 }

--- a/src/service/recordService.ts
+++ b/src/service/recordService.ts
@@ -235,7 +235,6 @@ const getRecord = async (
   const recordResponseDto: RecordResponseDto = {
     leftId: leftId,
     rightId: rightId,
-    userId: userId,
     record: recordDto,
     comments: recentComments,
   };
@@ -535,7 +534,6 @@ const getRecordNew = async (
   const recordResponseDto: RecordResponseDto = {
     leftId: leftId,
     rightId: rightId,
-    userId: userId,
     record: recordDto,
     comments: recentComments,
   };


### PR DESCRIPTION
## 🌱관련 이슈
Related to: 

## 📌 설명
원래 클라이언트에서 내가 작성한 댓글인지 아닌지를 확인하기 위해
현재 로그인한 유저의 아이디를 넘기는 작업을 했었는데
이를 서버에서 하기로 했음 -> 다시 제거하고

서버에서 댓글 응답에 현재 로그인한 유저가 작성한 댓글인지 boolean 값으로 리턴하는 방식으로 수정하기로 함
## ✅ 완료 목록

## ❓ 궁금한 점 & 리뷰 포인트
